### PR TITLE
feat: Post, Like, (임시) User Entity 정의, 공용 enum 타입 정의, 공용 Entity 정의

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,4 @@ out/
 ### VS Code ###
 .vscode/
 .idea/
-.src/main/resources/application.properties
+/src/main/resources/application.properties

--- a/src/main/java/org/example/snsapp/domain/like/entity/Like.java
+++ b/src/main/java/org/example/snsapp/domain/like/entity/Like.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.apache.catalina.User;
+import org.example.snsapp.domain.user.entity.User;
 import org.example.snsapp.global.entity.BaseEntity;
 
 @Entity

--- a/src/main/java/org/example/snsapp/domain/like/entity/Like.java
+++ b/src/main/java/org/example/snsapp/domain/like/entity/Like.java
@@ -1,0 +1,27 @@
+package org.example.snsapp.domain.like.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.apache.catalina.User;
+import org.example.snsapp.global.entity.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Like extends BaseEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+    @Column(nullable = false, length = 30)
+    private String type;
+    @Column(name = "type_id", nullable = false)
+    private Long typeId;
+
+    public Like(User user, String type, Long typeId) {
+        this.user = user;
+        this.type = type;
+        this.typeId = typeId;
+    }
+}

--- a/src/main/java/org/example/snsapp/domain/post/entity/Post.java
+++ b/src/main/java/org/example/snsapp/domain/post/entity/Post.java
@@ -1,4 +1,32 @@
 package org.example.snsapp.domain.post.entity;
 
-public class Post {
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.apache.catalina.User;
+import org.example.snsapp.global.entity.AuditableEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Post extends AuditableEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+    @Column(nullable = false, length = 30)
+    private String title;
+    @Column()
+    private String content;
+
+    public Post(User user, String title, String content) {
+        this.user = user;
+        this.title = title;
+        this.content = content;
+    }
+
+    public void update(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
 }

--- a/src/main/java/org/example/snsapp/domain/post/entity/Post.java
+++ b/src/main/java/org/example/snsapp/domain/post/entity/Post.java
@@ -1,0 +1,4 @@
+package org.example.snsapp.domain.post.entity;
+
+public class Post {
+}

--- a/src/main/java/org/example/snsapp/domain/post/entity/Post.java
+++ b/src/main/java/org/example/snsapp/domain/post/entity/Post.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.apache.catalina.User;
+import org.example.snsapp.domain.user.entity.User;
 import org.example.snsapp.global.entity.AuditableEntity;
 
 @Entity

--- a/src/main/java/org/example/snsapp/domain/user/entity/User.java
+++ b/src/main/java/org/example/snsapp/domain/user/entity/User.java
@@ -1,0 +1,8 @@
+package org.example.snsapp.domain.user.entity;
+
+import jakarta.persistence.Entity;
+import org.example.snsapp.global.entity.AuditableEntity;
+
+@Entity
+public class User extends AuditableEntity {
+}

--- a/src/main/java/org/example/snsapp/global/entity/AuditableEntity.java
+++ b/src/main/java/org/example/snsapp/global/entity/AuditableEntity.java
@@ -1,0 +1,15 @@
+package org.example.snsapp.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+public class AuditableEntity extends BaseEntity {
+    @LastModifiedDate
+    private LocalDateTime lastModified;
+}

--- a/src/main/java/org/example/snsapp/global/entity/AuditableEntity.java
+++ b/src/main/java/org/example/snsapp/global/entity/AuditableEntity.java
@@ -1,6 +1,5 @@
 package org.example.snsapp.global.entity;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import org.springframework.data.annotation.LastModifiedDate;

--- a/src/main/java/org/example/snsapp/global/entity/BaseEntity.java
+++ b/src/main/java/org/example/snsapp/global/entity/BaseEntity.java
@@ -1,0 +1,21 @@
+package org.example.snsapp.global.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/org/example/snsapp/global/enums/LikeContentType.java
+++ b/src/main/java/org/example/snsapp/global/enums/LikeContentType.java
@@ -1,0 +1,14 @@
+package org.example.snsapp.global.enums;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+enum LikeContentType {
+    POST("게시글"),
+    COMMENT("댓글");
+
+    private final String name;
+}

--- a/src/main/java/org/example/snsapp/global/enums/NotificationContentType.java
+++ b/src/main/java/org/example/snsapp/global/enums/NotificationContentType.java
@@ -1,0 +1,15 @@
+package org.example.snsapp.global.enums;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum NotificationContentType {
+    LIKE("좋아요"),
+    COMMENT("댓글"),
+    FOLLOW("팔로우");
+    
+    private final String name;
+}


### PR DESCRIPTION
* Post, Like의 Entity 정의
* 연관관계 매핑용 임시 User Entity 정의
* 공용 enum 타입인 LikeContentType 과 NotficationContetnType 정의
* 공용 Entity인 BaseEnity와 AuditableEntity 정의