### PR TITLE
refactor: User 엔티티 필드 제약 조건 통합 및 생성자 추가

### DIFF
--- a/src/main/java/org/example/snsapp/domain/user/entity/User.java
+++ b/src/main/java/org/example/snsapp/domain/user/entity/User.java
@@ -10,19 +10,30 @@ import org.example.snsapp.global.entity.AuditableEntity;
 @NoArgsConstructor
 public class User extends AuditableEntity {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    @Column(unique = true)
+    @Column(unique = true, nullable = false, length = 40)
     private String email;
 
+    @Column(nullable = false, length = 225)
     private String password;
 
+    @Column(nullable = false, length = 4)
     private String username;
 
+    @Column(nullable = false)
     private int age;
 
+    @Column(nullable = false, columnDefinition = "boolean default false")
     private boolean isResign;
 
+    @Column(length = 255)
     private String profileImage;
+
+    public User(String email, String password, String username, int age, boolean isResign, String profileImage) {
+        this.email = email;
+        this.password = password;
+        this.username = username;
+        this.age = age;
+        this.isResign = isResign;
+        this.profileImage = profileImage;
+    }
 }


### PR DESCRIPTION
## 변경 사항
- email: unique, nullable=false, length=40
- password: nullable=false, length=225
- username: nullable=false, length=4
- age: nullable=false
- isResign: nullable=false, default=false
- profileImage: length=255
- 모든 필드를 초기화할 수 있는 생성자 추가

## 참고
- 추후 필요 시 정적 팩토리 메서드 추가 가능
 - 정적 팩토리 메서드 예시:
```java
@Builder
private User(String email, String password, String username, int age, boolean isResign, String profileImage) {
    this.email = email;
    this.password = password;
    this.username = username;
    this.age = age;
    this.isResign = isResign;
    this.profileImage = profileImage;
}

public static User create(String email, String password, String username, int age, String profileImage) {
    return User.builder()
            .email(email)
            .password(password)
            .username(username)
            .age(age)
            .isResign(false)
            .profileImage(profileImage)
            .build();
}

public void updateUsernameAndProfile(String username, String profileImage) {
    this.username = username;
    this.profileImage = profileImage;
}
```